### PR TITLE
updated app setting for sessionconfigApplicationName

### DIFF
--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -265,7 +265,7 @@
                             },
                             {
                                 "name": "SessionConfig__ApplicationName",
-                                "value": "matchskills"
+                                "value": "session"
                             },
                             {
                                 "name": "DysacSettings__ApiUrl",


### PR DESCRIPTION
Please review and confirm. Updated app settings as requested.
MatchSkills setting:
"SessionConfig": {
    "ApplicationName": "session"