### PR TITLE
NCSD-3220 Added ApiVersion and updated ApiUrl in DysacSettings

### DIFF
--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -273,11 +273,15 @@
                             },
                             {
                                 "name": "DysacSettings__ApiUrl",
-                                "value": "[concat(parameters('apimProxyAddress'), '/discover-your-skills-careers/')]"
+                                "value": "[concat(parameters('apimProxyAddress'), '/discover-skills-and-careers/')]"
                             },
                             {
                                 "name": "DysacSettings__ApiKey",
                                 "value": "[parameters('apimDysacApiKey')]"
+                            },
+                            {
+                                "name": "DysacSettings__ApiVersion",
+                                "value": "v1"
                             },
                             {
                                 "name": "DysacSettings__DysacUrl",


### PR DESCRIPTION
NCSD-3220

Hi Team can we please modify the following settings for Matchskills.
DysacSettings
Add =>    "ApiVersion": "v1",
Update =>
"ApiUrl": "https://dev.api.nationalcareersservice.org.uk/discover-skills-and-careers/",