### PR TITLE
Added App Settings for Match Skills - NCSD-3286

### DIFF
--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -48,6 +48,9 @@
             "value": "__CompositeUiCdnUrl__"
         },
         "apimDysacApiKey": {
+            "value": "__ApimDiscoverSkillsAndCareersKey__"
+        },
+        "apimoldDysacApiKey": {
             "value": "__ApimDiscoverMySkillsAndCareersKey__"
         }
     }

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -51,6 +51,9 @@
         },
         "apimDysacApiKey": {
             "type": "securestring"
+        },
+        "apimoldDysacApiKey": {
+            "type": "securestring"
         }
     },
     "variables": {
@@ -280,12 +283,28 @@
                                 "value": "[parameters('apimDysacApiKey')]"
                             },
                             {
+                                "name": "OldDysacSettings__ApiKey",
+                                "value": "[parameters('apimoldDysacApiKey')]"
+                            },
+                            {
+                                "name": "OldDysacSettings__AssessmentApiUrl",
+                                "value": "[concat(parameters('apimProxyAddress'), '/assessments/api/assessment/')]"
+                            },
+                            {
                                 "name": "DysacSettings__ApiVersion",
                                 "value": "v1"
                             },
                             {
                                 "name": "DysacSettings__DysacUrl",
                                 "value": "/discover-your-skills-careers/assessment/short/1"
+                            },
+                            {
+                                "name": "DysacSettings__DysacSaveUrl",
+                                "value": "/discover-your-skills-careers/Assessment/save"
+                            },
+                            {
+                                "name": "DysacSettings__DysacReturnUrl",
+                                "value": "/discover-your-skills-careers/assessment/return"
                             },
                             {
                                 "name": "LmiSettings__CacheLifespan",

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -49,6 +49,9 @@
         },
         "apimDysacApiKey": {
             "value": "not-a-real-apim-key"
+        },
+        "apimoldDysacApiKey": {
+            "value": "not-a-real-apim-key"
         }
     }
 }


### PR DESCRIPTION
New Request from Stephen Yates to add the following settings on to dev and sit, The API key is for old disc
DysacSettings__DysacSaveUrl = "/discover-your-skills-careers/Assessment/save"
DysacSettings__DysacReturnUrl = "/discover-your-skills-careers/assessment/return"
OldDysacSettings__ApiKey = Old dysac api key
OldDysacSettings__AssessmentApiUrl = example https://dev.api.nationalcareersservice.org.uk/assessments/api/assessment/

From Stephen Yates